### PR TITLE
Reboot du gate assigner

### DIFF
--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -677,13 +677,15 @@ void CoFrancePlugIn::OnRadarTargetPositionUpdate(CRadarTarget RadarTarget)
     if (ScratchPad.find("STAND=") != std::string::npos)
         return;
 
+    DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Scratchpad OK for " + string(CorrFp.GetCallsign()), false, false, false, false, false);
+
     
     if (std::find(StandApiAvailableFor.begin(), StandApiAvailableFor.end(), string(CorrFp.GetFlightPlanData().GetDestination())) != StandApiAvailableFor.end()) {
 
         if (CorrFp.GetDistanceToDestination() < 10) {
-           
+            DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Distance OK, Checking stand for " + string(CorrFp.GetCallsign()), false, false, false, false, false);
             if (PendingStands.find(string(CorrFp.GetCallsign())) == PendingStands.end()) {
-                
+                DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Inserting " + string(CorrFp.GetCallsign()), false, false, false, false, false);
                 PendingStands.insert(std::make_pair(string(CorrFp.GetCallsign()), 
                     async(&CoFrancePlugIn::LoadRemoteStandAssignment, this, string(CorrFp.GetCallsign()), string(CorrFp.GetFlightPlanData().GetOrigin()),
                         string(CorrFp.GetFlightPlanData().GetDestination()),
@@ -825,18 +827,19 @@ string CoFrancePlugIn::LoadRemoteStandAssignment(string callsign, string origin,
         params.emplace("arr", destination);
         params.emplace("wtc", wtc);
 
-
+        DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Preparing query for " + callsign, false, false, false, false, false);   
         if (auto res = cli.Post(CONFIG_ONLINE_STAND_API_QUERY_URL_PATH, params)) {
             if (res->status == 200) {
                 
                 std::istringstream is(res->body, std::ios_base::binary | std::ios_base::in);
 
                 toml::value StandData = toml::parse(is, "std::string");
-
+                DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Query succes for " + callsign, false, false, false, false, false);      
                 cli.stop();
                 return toml::find<string>(StandData, "data", "stand");
             }
             else {
+                DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Query failed (not 200) " + callsign, false, false, false, false, false);   
                 cli.stop();
                 return "NoGate";
             }
@@ -845,9 +848,8 @@ string CoFrancePlugIn::LoadRemoteStandAssignment(string callsign, string origin,
         cli.stop();
     }
     catch (const std::exception& exc) {
-        
-    }
-
+        DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "ERROR for" + callsign, false, false, false, false, false);   
+    }   
     return "NoGate";
 }
 

--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -677,15 +677,13 @@ void CoFrancePlugIn::OnRadarTargetPositionUpdate(CRadarTarget RadarTarget)
     if (ScratchPad.find("STAND=") != std::string::npos)
         return;
 
-    DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Scratchpad OK for " + string(CorrFp.GetCallsign()), false, false, false, false, false);
-
     
     if (std::find(StandApiAvailableFor.begin(), StandApiAvailableFor.end(), string(CorrFp.GetFlightPlanData().GetDestination())) != StandApiAvailableFor.end()) {
 
         if (CorrFp.GetDistanceToDestination() < 10) {
-            DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Distance OK, Checking stand for " + string(CorrFp.GetCallsign()), false, false, false, false, false);
+           
             if (PendingStands.find(string(CorrFp.GetCallsign())) == PendingStands.end()) {
-                DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Inserting " + string(CorrFp.GetCallsign()), false, false, false, false, false);
+                
                 PendingStands.insert(std::make_pair(string(CorrFp.GetCallsign()), 
                     async(&CoFrancePlugIn::LoadRemoteStandAssignment, this, string(CorrFp.GetCallsign()), string(CorrFp.GetFlightPlanData().GetOrigin()),
                         string(CorrFp.GetFlightPlanData().GetDestination()),
@@ -827,19 +825,18 @@ string CoFrancePlugIn::LoadRemoteStandAssignment(string callsign, string origin,
         params.emplace("arr", destination);
         params.emplace("wtc", wtc);
 
-        DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Preparing query for " + callsign, false, false, false, false, false);   
+
         if (auto res = cli.Post(CONFIG_ONLINE_STAND_API_QUERY_URL_PATH, params)) {
             if (res->status == 200) {
                 
                 std::istringstream is(res->body, std::ios_base::binary | std::ios_base::in);
 
                 toml::value StandData = toml::parse(is, "std::string");
-                DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Query succes for " + callsign, false, false, false, false, false);      
+
                 cli.stop();
                 return toml::find<string>(StandData, "data", "stand");
             }
             else {
-                DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "Query failed (not 200) " + callsign, false, false, false, false, false);   
                 cli.stop();
                 return "NoGate";
             }
@@ -848,8 +845,9 @@ string CoFrancePlugIn::LoadRemoteStandAssignment(string callsign, string origin,
         cli.stop();
     }
     catch (const std::exception& exc) {
-        DisplayUserMessage("Message", "[STANDS] CoFrance PlugIn", "ERROR for" + callsign, false, false, false, false, false);   
-    }   
+        
+    }
+
     return "NoGate";
 }
 

--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -730,9 +730,9 @@ void CoFrancePlugIn::LoadConfigFile(bool fromWeb)
         DisplayUserMessage("Message", "CoFrance PlugIn", string("Error reading config file " + string(exc.what())).c_str(), false, false, false, false, false);
     }
 
-    //DisplayUserMessage("Message", "CoFrance PlugIn", "Reading stand API config...", false, false, false, false, false);
+    DisplayUserMessage("Message", "CoFrance PlugIn", "Reading stand API config...", false, false, false, false, false);
 
-    /*try {
+    try {
         if (fromWeb) {
             httplib::Client cli(API_URL_BASE);
             if (auto res = cli.Get(CONFIG_ONLINE_STAND_API_URL_PATH)) {
@@ -754,7 +754,7 @@ void CoFrancePlugIn::LoadConfigFile(bool fromWeb)
     }
     catch (const std::exception& exc) {
         DisplayUserMessage("Message", "CoFrance PlugIn", string("Error reading stand api file " + string(exc.what())).c_str(), false, false, false, false, false);
-    }*/
+    }
 }
 
 string CoFrancePlugIn::SendCPDLCActiveAircrafts(string my_callsign, string message)

--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -734,7 +734,7 @@ void CoFrancePlugIn::LoadConfigFile(bool fromWeb)
 
     /*try {
         if (fromWeb) {
-            httplib::Client cli(CONFIG_ONLINE_URL_BASE);
+            httplib::Client cli(API_URL_BASE);
             if (auto res = cli.Get(CONFIG_ONLINE_STAND_API_URL_PATH)) {
                 if (res->status == 200) {
                     std::istringstream is(res->body, std::ios_base::binary | std::ios_base::in);
@@ -818,7 +818,7 @@ string CoFrancePlugIn::SendCPDLCEvent(string ac_callsign, int event_type, string
 string CoFrancePlugIn::LoadRemoteStandAssignment(string callsign, string origin, string destination, string wtc)
 {
     try {
-        httplib::Client cli(CONFIG_ONLINE_URL_BASE);
+        httplib::Client cli(API_URL_BASE);
         httplib::Params params;
         params.emplace("callsign", callsign);
         params.emplace("dep", origin);

--- a/Constants.h
+++ b/Constants.h
@@ -13,6 +13,7 @@
 
 #define CONFIG_ONLINE_URL_BASE "https://raw.githubusercontent.com"
 #define CONFIG_ONLINE_URL_PATH "/vaccfr/CoFrance/master/config.toml"
+#define API_URL_BASE "https://fire-ops.ew.r.appspot.com"
 #define CONFIG_ONLINE_STAND_API_URL_PATH "/api/cfr/stand"
 #define CONFIG_ONLINE_STAND_API_QUERY_URL_PATH "/api/cfr/stand/query"
 


### PR DESCRIPTION
@p7x404 cette PR n'a pas vocation à être merge immédiatement.
En gros l'idée est de conserver la gestion du toml de config telle qu'elle est actuellement (hosted by github), mais de définir un nouveau endpoint pour l'API qui se chargera de répondre au système d'assignation de gates.

Donc il faudrait que nous étudions la possibilité de réactiver ce système, pour du display only dans le tag AVISO concerné.
L'idée est d'uniquement utiliser le système de gate en lecture seule, sans changer sont fonctionnement actuel (si possible), et donc ne pas réactiver la partie qui permet de forcer un stand coté ES.

Dans les next steps : 
- j'active le endpoint http associé à CONFIG_ONLINE_STAND_API_URL_PATH pour qu'il renvoie une erreur/message acceptable par cofrance, en attendant que le système coté serveur soit fini
- on test qu'il n'y a pas de side effect, et on prend les devants pour release tout ça dans une future MaJ AIRAC

A dispo pour en discuter