### PR TITLE
Gate assigner reboot with refresh

### DIFF
--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -503,7 +503,7 @@ void CoFrancePlugIn::OnTimer(int Counter)
             std::string stand = it->second.get();
 
             string ScratchPad = FlightPlanSelect(it->first.c_str()).GetControllerAssignedData().GetScratchPadString();
-            ScratchPad = "STAND=" + stand + " " + ScratchPad;
+            ScratchPad = BuildScratchPadWithStand(ScratchPad, stand);
             FlightPlanSelect(it->first.c_str()).GetControllerAssignedData().SetScratchPadString(ScratchPad.c_str());
             if (AssignedStandTime.find(it->first.c_str()) != AssignedStandTime.end()) {
                 AssignedStandTime[it->first.c_str()] = std::chrono::system_clock::now();
@@ -911,4 +911,25 @@ string CoFrancePlugIn::LoadOCLData()
     return "[]";
 
     //return "[ { \"callsign\": \"BER1PE\", \"status\": \"CLEARED\", \"nat\": \"A\", \"fix\": \"MALOT\", \"level\": \"320\", \"mach\": \"0.89\", \"estimating_time\": \"1921\", \"clearance_issued\": \"2021-03-26 00:21:19\", \"extra_info\": \"CROSS MALOT NOT BEFORE 1925\" }, { \"callsign\":\"ADB3908\", \"status\":\"PENDING\", \"nat\":\"RR\", \"fix\":\"PORTI\", \"level\": \"350\", \"mach\": \"0.82\", \"estimating_time\":\"18:41\", \"clearance_issued\":null, \"extra_info\":null } ]";
+}
+
+string CoFrancePlugIn::BuildScratchPadWithStand(string currentScratchPad, string stand)
+{
+    std::size_t standBegin, standEnd;
+    string cleanScratchPad;
+
+    standBegin = currentScratchPad.find("STAND=");
+    if (standBegin != std::string::npos) {
+        standEnd = currentScratchPad.find(" ", standBegin);
+        if (standEnd != std::string::npos) {
+            cleanScratchPad = currentScratchPad.replace(standBegin, standEnd - standBegin + 1, "");
+        }
+        else {
+            cleanScratchPad = currentScratchPad.replace(standBegin, currentScratchPad.size() - standBegin, "");
+        }
+    }
+    else {
+        cleanScratchPad = currentScratchPad;
+    }
+    return "STAND=" + stand + " " + cleanScratchPad;
 }

--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -730,9 +730,9 @@ void CoFrancePlugIn::LoadConfigFile(bool fromWeb)
         DisplayUserMessage("Message", "CoFrance PlugIn", string("Error reading config file " + string(exc.what())).c_str(), false, false, false, false, false);
     }
 
-    //DisplayUserMessage("Message", "CoFrance PlugIn", "Reading stand API config...", false, false, false, false, false);
+    DisplayUserMessage("Message", "CoFrance PlugIn", "Reading stand API config...", false, false, false, false, false);
 
-    /*try {
+    try {
         if (fromWeb) {
             httplib::Client cli(API_URL_BASE);
             if (auto res = cli.Get(CONFIG_ONLINE_STAND_API_URL_PATH)) {
@@ -754,7 +754,7 @@ void CoFrancePlugIn::LoadConfigFile(bool fromWeb)
     }
     catch (const std::exception& exc) {
         DisplayUserMessage("Message", "CoFrance PlugIn", string("Error reading stand api file " + string(exc.what())).c_str(), false, false, false, false, false);
-    }*/
+    }
 }
 
 string CoFrancePlugIn::SendCPDLCActiveAircrafts(string my_callsign, string message)

--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -83,6 +83,17 @@ bool CoFrancePlugIn::OnCompileCommand(const char* sCommandLine)
         return true;
     }
 
+     if (strcmp(sCommandLine, ".cofrance debug") == 0) {
+        Debug = !Debug;
+        if (Debug) {
+            DisplayUserMessage("CoFrance", "Debug", "Debug enabled", true, true, false, true, false);
+        }
+        else {
+            DisplayUserMessage("CoFrance", "Debug", "Debug disabled", true, true, false, true, false);
+        }
+        return true;
+    }
+
     if (strcmp(sCommandLine, ".cofrance stand") == 0) {
         StandAssignerEnabled = !StandAssignerEnabled;
         if (StandAssignerEnabled) {
@@ -511,7 +522,9 @@ void CoFrancePlugIn::OnTimer(int Counter)
             else {
                 AssignedStandTime.insert(make_pair(it->first.c_str(), std::chrono::system_clock::now()));
             }
-            DisplayUserMessage("CoFrance", "Stand", string("Recieved stand " + stand + " for " + it->first.c_str()).c_str(), true, false, false, false, false);
+            if (Debug) {
+                DisplayUserMessage("CoFrance", "Stand", string("Recieved stand " + stand + " for " + it->first.c_str()).c_str(), true, false, false, false, false);
+            }
             must_delete = true;
         }
 
@@ -708,7 +721,9 @@ void CoFrancePlugIn::OnRadarTargetPositionUpdate(CRadarTarget RadarTarget)
             if (CorrFp.GetDistanceToDestination() < 10) {
 
                 if (PendingStands.find(string(CorrFp.GetCallsign())) == PendingStands.end()) {
-                    DisplayUserMessage("CoFrance", "Stand", string("Requesting stand for " + string(CorrFp.GetCallsign())).c_str(), true, false, false, false, false);
+                    if (Debug) {
+                        DisplayUserMessage("CoFrance", "Stand", string("Requesting stand for " + string(CorrFp.GetCallsign())).c_str(), true, false, false, false, false);
+                    }
                     PendingStands.insert(std::make_pair(string(CorrFp.GetCallsign()),
                         async(&CoFrancePlugIn::LoadRemoteStandAssignment, this, string(CorrFp.GetCallsign()), string(CorrFp.GetFlightPlanData().GetOrigin()),
                             string(CorrFp.GetFlightPlanData().GetDestination()),

--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -734,7 +734,7 @@ void CoFrancePlugIn::LoadConfigFile(bool fromWeb)
 
     /*try {
         if (fromWeb) {
-            httplib::Client cli(CONFIG_ONLINE_URL_BASE);
+            httplib::Client cli(API_URL_BASE);
             if (auto res = cli.Get(CONFIG_ONLINE_STAND_API_URL_PATH)) {
                 if (res->status == 200) {
                     std::istringstream is(res->body, std::ios_base::binary | std::ios_base::in);
@@ -818,7 +818,7 @@ string CoFrancePlugIn::SendCPDLCEvent(string ac_callsign, int event_type, string
 string CoFrancePlugIn::LoadRemoteStandAssignment(string callsign, string origin, string destination, string wtc)
 {
     try {
-        httplib::Client cli(CONFIG_ONLINE_URL_BASE);
+        httplib::Client cli(API_URL_BASE);
         httplib::Params params;
         params.emplace("callsign", callsign);
         params.emplace("dep", origin);

--- a/CoFrancePlugIn.h
+++ b/CoFrancePlugIn.h
@@ -40,14 +40,18 @@ public:
 
     void OnRadarTargetPositionUpdate(CRadarTarget RadarTarget);
 
+    void OnFlightPlanDisconnect(CFlightPlan FlightPlan);
+
     toml::value CoFranceConfig;
     vector<string> StandApiAvailableFor;
     map<string, future<string>> PendingStands;
+    map<string, std::chrono::system_clock::time_point> AssignedStandTime;
     string DetailedAircraft;
     string DllPath;
     map<string, string> ConflictGroups;
     bool CanLoadRadarScreen = true;
     bool Blink = false;
+    double StandAssignmentRefresh = 30;
 
     CSTCA *Stca = nullptr;
 

--- a/CoFrancePlugIn.h
+++ b/CoFrancePlugIn.h
@@ -51,6 +51,7 @@ public:
     map<string, string> ConflictGroups;
     bool CanLoadRadarScreen = true;
     bool Blink = false;
+    bool StandAssignerEnabled = true;
     double StandAssignmentRefresh = 30;
 
     CSTCA *Stca = nullptr;

--- a/CoFrancePlugIn.h
+++ b/CoFrancePlugIn.h
@@ -64,6 +64,8 @@ public:
 
     string LoadOCLData();
 
+    string BuildScratchPadWithStand(string currentScratchPad, string stand);
+
     GdiplusStartupInput gdiplusStartupInput;
     ULONG_PTR gdiplusToken;
 

--- a/CoFrancePlugIn.h
+++ b/CoFrancePlugIn.h
@@ -51,6 +51,7 @@ public:
     map<string, string> ConflictGroups;
     bool CanLoadRadarScreen = true;
     bool Blink = false;
+    bool Debug = false;
     bool StandAssignerEnabled = true;
     double StandAssignmentRefresh = 30;
 

--- a/Constants.h
+++ b/Constants.h
@@ -40,6 +40,10 @@ namespace CoFranceTags {
     const int CPDLC_STATUS = 18;
     const int OCL_FLAG = 19;
     const int ASSIGNED_SPEED = 20;
+    const int STAND = 21;
+
+    const int ANNOTATION_SPEED_SIGN = 2;
+    const int ANNOTATION_STAND = 3;
 
     const int FUNCTION_CONFLICT_POPUP = 500;
     const int FUNCTION_HANDLE_CONFLICT_GROUP = 501;
@@ -54,6 +58,9 @@ namespace CoFranceTags {
     const int FUNCTION_ASP_TOOL_TOGGLE_M = 904;
     const int FUNCTION_ASP_TOOL_RESUME = 905;
     const int FUNCTION_ASP_TOOL_CANCEL = 906;
+
+    const int FUNCTION_STAND_MENU = 907;
+    const int FUNCTION_STAND_CLEAR = 908;
 }
 
 namespace CoFranceCharacters {

--- a/Constants.h
+++ b/Constants.h
@@ -13,6 +13,7 @@
 
 #define CONFIG_ONLINE_URL_BASE "https://raw.githubusercontent.com"
 #define CONFIG_ONLINE_URL_PATH "/vaccfr/CoFrance/master/config.toml"
+#define API_URL_BASE "https://fire-ops.ew.r.appspot.com"
 #define CONFIG_ONLINE_STAND_API_URL_PATH "/api/cfr/stand"
 #define CONFIG_ONLINE_STAND_API_QUERY_URL_PATH "/api/cfr/stand/query"
 

--- a/PopupSpeedAssign.h
+++ b/PopupSpeedAssign.h
@@ -66,10 +66,10 @@ public:
 			if (aspeed != 0 && aspeed % 10 == 1)
 				min_active = true;
 
-			if (mach != 0 && string(fp.GetControllerAssignedData().GetFlightStripAnnotation(2)) == string("-"))
+			if (mach != 0 && string(fp.GetControllerAssignedData().GetFlightStripAnnotation(CoFranceTags::ANNOTATION_SPEED_SIGN)) == string("-"))
 				max_active = true;
 
-			if (mach != 0 && string(fp.GetControllerAssignedData().GetFlightStripAnnotation(2)) == string("+"))
+			if (mach != 0 && string(fp.GetControllerAssignedData().GetFlightStripAnnotation(CoFranceTags::ANNOTATION_SPEED_SIGN)) == string("+"))
 				min_active = true;
 
 			initialise = false;

--- a/RadarScreen.cpp
+++ b/RadarScreen.cpp
@@ -217,7 +217,7 @@ void RadarScreen::OnRefresh(HDC hDC, int Phase)
 				size_t tp_decimal_pos = tp_distanceText.find(".");
 				tp_distanceText = tp_distanceText.substr(0, tp_decimal_pos + 2) + "Nm";
 
-				tp_distanceText = tp_distanceText + " " + tp_headingText + "ï¿½";
+				tp_distanceText = tp_distanceText + " " + tp_headingText + "°";
 				
 				
 				dc.TextOutA(OffsetText.X, OffsetText.Y, tp_distanceText.c_str());
@@ -268,7 +268,7 @@ void RadarScreen::OnRefresh(HDC hDC, int Phase)
 					size_t decimal_pos = distanceText.find(".");
 					distanceText = distanceText.substr(0, decimal_pos + 2)+"Nm";
 
-					distanceText = distanceText + " " + headingText + "ï¿½";
+					distanceText = distanceText + " " + headingText + "°";
 
 					POINT MidPointDistance = { (int)((FirstPos.x + SecondPos.x) / 2), (int)((FirstPos.y + SecondPos.y) / 2) };
 

--- a/RadarScreen.cpp
+++ b/RadarScreen.cpp
@@ -217,7 +217,7 @@ void RadarScreen::OnRefresh(HDC hDC, int Phase)
 				size_t tp_decimal_pos = tp_distanceText.find(".");
 				tp_distanceText = tp_distanceText.substr(0, tp_decimal_pos + 2) + "Nm";
 
-				tp_distanceText = tp_distanceText + " " + tp_headingText + "°";
+				tp_distanceText = tp_distanceText + " " + tp_headingText + "ï¿½";
 				
 				
 				dc.TextOutA(OffsetText.X, OffsetText.Y, tp_distanceText.c_str());
@@ -268,7 +268,7 @@ void RadarScreen::OnRefresh(HDC hDC, int Phase)
 					size_t decimal_pos = distanceText.find(".");
 					distanceText = distanceText.substr(0, decimal_pos + 2)+"Nm";
 
-					distanceText = distanceText + " " + headingText + "°";
+					distanceText = distanceText + " " + headingText + "ï¿½";
 
 					POINT MidPointDistance = { (int)((FirstPos.x + SecondPos.x) / 2), (int)((FirstPos.y + SecondPos.y) / 2) };
 
@@ -621,7 +621,7 @@ void RadarScreen::OnClickScreenObject(int ObjectType, const char* sObjectId, POI
 		if (fp.GetTrackingControllerIsMe()) {
 			fp.GetControllerAssignedData().SetAssignedMach(0);
 			fp.GetControllerAssignedData().SetAssignedSpeed(0);
-			fp.GetControllerAssignedData().SetFlightStripAnnotation(2, "");
+			fp.GetControllerAssignedData().SetFlightStripAnnotation(CoFranceTags::ANNOTATION_SPEED_SIGN, "");
 		}
 
 		aspPopup.Reset();
@@ -641,16 +641,16 @@ void RadarScreen::OnClickScreenObject(int ObjectType, const char* sObjectId, POI
 			if (aspPopup.is_mach) {
 				int selected = stoi(sObjectId);
 				if (aspPopup.max_active)
-					fp.GetControllerAssignedData().SetFlightStripAnnotation(2, "-");
+					fp.GetControllerAssignedData().SetFlightStripAnnotation(CoFranceTags::ANNOTATION_SPEED_SIGN, "-");
 				else if (aspPopup.min_active)
-					fp.GetControllerAssignedData().SetFlightStripAnnotation(2, "+");
+					fp.GetControllerAssignedData().SetFlightStripAnnotation(CoFranceTags::ANNOTATION_SPEED_SIGN, "+");
 				else
-					fp.GetControllerAssignedData().SetFlightStripAnnotation(2, "");
+					fp.GetControllerAssignedData().SetFlightStripAnnotation(CoFranceTags::ANNOTATION_SPEED_SIGN, "");
 				fp.GetControllerAssignedData().SetAssignedMach(selected);
 			}
 			else {
 				int selected = stoi(sObjectId);
-				fp.GetControllerAssignedData().SetFlightStripAnnotation(2, "");
+				fp.GetControllerAssignedData().SetFlightStripAnnotation(CoFranceTags::ANNOTATION_SPEED_SIGN, "");
 				if (aspPopup.max_active)
 					selected--;
 				if (aspPopup.min_active)


### PR DESCRIPTION
Re-enable the gate assigner in CoFrance:
- Refresh the gate every 30 seconds
- Add command `.cofrance stand` to disable/enable the auto assigner (enabled by default)
- Add command `.cofrance debug` to display the API queries and responses (disabled by default)