### PR TITLE
Remove code related GateAssigner 

### DIFF
--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -55,6 +55,8 @@ CoFrancePlugIn::CoFrancePlugIn(void):CPlugIn(EuroScopePlugIn::COMPATIBILITY_CODE
 
     RegisterTagItemFunction("Open ASP Popup", CoFranceTags::FUNCTION_OPEN_ASP);
 
+    RegisterTagItemType("Stand", CoFranceTags::STAND);
+
     DisplayUserMessage("Message", "CoFrance PlugIn", string("Version " + string(MY_PLUGIN_VERSION) + " loaded.").c_str(), false, false, false, false, false);
 }
 
@@ -494,7 +496,13 @@ void CoFrancePlugIn::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarg
         else {
             strcpy_s(sItemString, 16, "");
         }
+    }
 
+    if (ItemCode == CoFranceTags::STAND) {
+        if (!FlightPlan.IsValid())
+            return;
+
+        strcpy_s(sItemString, 16, "INOP");
     }
 }
 

--- a/CoFrancePlugIn.h
+++ b/CoFrancePlugIn.h
@@ -36,24 +36,14 @@ public:
 
     void OnFlightPlanControllerAssignedDataUpdate(CFlightPlan FlightPlan, int DataType);
 
-    string LoadRemoteStandAssignment(string callsign, string origin, string destination, string wtc);
-
-    void OnRadarTargetPositionUpdate(CRadarTarget RadarTarget);
-
-    void OnFlightPlanDisconnect(CFlightPlan FlightPlan);
-
     toml::value CoFranceConfig;
-    vector<string> StandApiAvailableFor;
-    map<string, future<string>> PendingStands;
-    map<string, std::chrono::system_clock::time_point> AssignedStandTime;
+
     string DetailedAircraft;
     string DllPath;
     map<string, string> ConflictGroups;
     bool CanLoadRadarScreen = true;
     bool Blink = false;
     bool Debug = false;
-    bool StandAssignerEnabled = true;
-    double StandAssignmentRefresh = 30;
 
     CSTCA *Stca = nullptr;
 
@@ -64,8 +54,6 @@ public:
     string SendCPDLCEvent(string ac_callsign, int event_type, string value);
 
     string LoadOCLData();
-
-    string BuildScratchPadWithStand(string currentScratchPad, string stand);
 
     GdiplusStartupInput gdiplusStartupInput;
     ULONG_PTR gdiplusToken;

--- a/Constants.h
+++ b/Constants.h
@@ -13,9 +13,6 @@
 
 #define CONFIG_ONLINE_URL_BASE "https://raw.githubusercontent.com"
 #define CONFIG_ONLINE_URL_PATH "/vaccfr/CoFrance/master/config.toml"
-#define API_URL_BASE "https://fire-ops.ew.r.appspot.com"
-#define CONFIG_ONLINE_STAND_API_URL_PATH "/api/cfr/stand"
-#define CONFIG_ONLINE_STAND_API_QUERY_URL_PATH "/api/cfr/stand/query"
 
 using namespace std;
 using namespace EuroScopePlugIn;
@@ -58,9 +55,6 @@ namespace CoFranceTags {
     const int FUNCTION_ASP_TOOL_TOGGLE_M = 904;
     const int FUNCTION_ASP_TOOL_RESUME = 905;
     const int FUNCTION_ASP_TOOL_CANCEL = 906;
-
-    const int FUNCTION_STAND_MENU = 907;
-    const int FUNCTION_STAND_CLEAR = 908;
 }
 
 namespace CoFranceCharacters {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,5 +9,11 @@
         "cpp-httplib",
         "toml11"
     ],
-   "builtin-baseline": "2b322364f06308bdd24823f9d8f03fe0cc86fd46f"
+   "builtin-baseline": "7220a4eebf20515cdd9c34721e15ca082bae9038",
+    "overrides": [
+        {
+            "name": "cpp-httplib",
+            "version": "0.18.3"
+        }
+    ]
   }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,5 +8,6 @@
         "nlohmann-json",
         "cpp-httplib",
         "toml11"
-    ]
+    ],
+   "builtin-baseline": "2b322364f06308bdd24823f9d8f03fe0cc86fd46f"
   }


### PR DESCRIPTION
The GateAssigner is being replaced by the RampAgent (new API and [Euroscope plugin](https://github.com/AlexisBalzano/EuroscopeRampAgent)).

Force a specific version of `ccp-httplib` library to fix an issue during build:
```
cpp-httplib is only supported on '!x86 & !arm32', which does not match x86-windows-static
```