### PR TITLE
Fix encoding issue with Github Windows runner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set version in header and resource files
         run: |
-          (Get-Content Constants.h).replace('@appveyor_build', '${{ steps.get_version.outputs.version }}') | Set-Content Constants.h
+          (Get-Content CoFrancePlugIn.h).replace('@appveyor_build', '${{ steps.get_version.outputs.version }}') | Set-Content CoFrancePlugIn.h
           (Get-Content CoFrance.rc).replace('@appveyor_build', '${{ steps.get_version.outputs.version }}') | Set-Content CoFrance.rc
 
       - name: Build DLL

--- a/CoFrancePlugIn.h
+++ b/CoFrancePlugIn.h
@@ -9,6 +9,11 @@
 #include "STCA.h"
 #include "nlohmann/json.hpp"
 
+#define MY_PLUGIN_NAME "CoFrance"
+#define MY_PLUGIN_VERSION "@appveyor_build"
+#define MY_PLUGIN_DEVELOPER "Pierre Ferran"
+#define MY_PLUGIN_COPYRIGHT "GPL v3"
+
 using namespace EuroScopePlugIn;
 using namespace Gdiplus;
 using namespace std;

--- a/Constants.h
+++ b/Constants.h
@@ -6,11 +6,6 @@
 #include <sstream>
 #include "nlohmann/json.hpp"
 
-#define MY_PLUGIN_NAME "CoFrance"
-#define MY_PLUGIN_VERSION "@appveyor_build"
-#define MY_PLUGIN_DEVELOPER "Pierre Ferran"
-#define MY_PLUGIN_COPYRIGHT "GPL v3"
-
 #define CONFIG_ONLINE_URL_BASE "https://raw.githubusercontent.com"
 #define CONFIG_ONLINE_URL_PATH "/vaccfr/CoFrance/master/config.toml"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ platform: x86
 configuration: Release
 
 build_script:
-  - ps: (Get-Content  C:\projects\cofrance\Constants.h).replace('@appveyor_build', $Env:appveyor_build_version) | Set-Content  C:\projects\cofrance\Constants.h
+  - ps: (Get-Content  C:\projects\cofrance\CoFrancePlugIn.h).replace('@appveyor_build', $Env:appveyor_build_version) | Set-Content  C:\projects\cofrance\CoFrancePlugIn.h
   - ps: (Get-Content  C:\projects\cofrance\CoFrance.rc).replace('@appveyor_build', $Env:appveyor_build_version) | Set-Content  C:\projects\cofrance\CoFrance.rc
   - cmd: msbuild "C:\projects\cofrance\CoFrance.sln" /p:VcpkgEnableManifest=true /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 


### PR DESCRIPTION
`Get-Content` and `Set-Content` have different behaviors regarding encoding between:
- PowerShell 5 installed on AppVeyor image `Visual Studio 2022`
- Powershell 7 installed on Github Action runner `windows-latest` (`windows-2025` as of today)

This PR moves the MY_PLUGIN_VERSION and other constants to different header file than `Constants.h` to prevent any modification of:
```
namespace CoFranceCharacters {
    const string Moon = "±";
    const string Star = "§";
    const string Losange = "÷";
    const string Pen = "µ";
    const string ClearedVisualIndicator = "©";
    const string ClearedAPPIndicator = "®";
    const string DatalinkIndicator = "ß";
}
```

The `@appveyor_build` replacement via `Get-Content` and `Set-Content` is done on `CoFrancePlugIn.h` instead of `Constants.h`.