### PR TITLE
OCL: Disable by default, fix toggle button

### DIFF
--- a/CoFrance.vcxproj
+++ b/CoFrance.vcxproj
@@ -91,6 +91,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>lib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -114,6 +115,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_WINDOWS;_DEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+	  <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -139,6 +141,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>lib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+	  <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -166,6 +169,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_WINDOWS;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+	  <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/CoFrance.vcxproj.filters
+++ b/CoFrance.vcxproj.filters
@@ -74,6 +74,9 @@
     <ClInclude Include="PopupSpeedAssign.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DYPWindow.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="CoFrance.rc">

--- a/CoFrancePlugIn.cpp
+++ b/CoFrancePlugIn.cpp
@@ -495,8 +495,8 @@ void CoFrancePlugIn::OnTimer(int Counter)
     if (Counter % 3 == 0 && !performanceMode)
         Stca->OnRefresh(this);
 
-    // Every 5 seconds poll OCL data
-    if (Counter % 5 == 0) {
+    // Every 30 seconds poll OCL data
+    if (Counter % 30 == 0) {
         if (ControllerMyself().IsValid() && ControllerMyself().IsController()) {
             if (SharedData::OCLEnabled) {
                 // Don't start a new OCL fetch if the previous one is still in-flight.

--- a/Constants.h
+++ b/Constants.h
@@ -83,12 +83,12 @@ namespace StaticColours {
 }
 
 namespace SharedData {
-    static bool OCLEnabled = true;
-    static nlohmann::json OCLData;
+    inline bool OCLEnabled = false;
+    inline nlohmann::json OCLData;
 
-    static auto OCL_Tooltip_timer = std::chrono::system_clock::now();
-    static string OCL_Tooltip_string;
-    static POINT OCL_Tooltip_pt;
+    inline auto OCL_Tooltip_timer = std::chrono::system_clock::now();
+    inline string OCL_Tooltip_string;
+    inline POINT OCL_Tooltip_pt;
 }
 
 static bool HasOCL(string callsign) {


### PR DESCRIPTION
* Change default poll interval to 30 seconds
* Use `inline` variables instead of static to ensure proper state propagation between namespaces
* `inline` variables requires `C++17`